### PR TITLE
v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,66 @@
-Network Scanner (macOS + Linux)
-================================
+# Network Scanner (macOS + Linux)
 
-Ein einfacher, stabiler und erweiterbarer Netzwerkscanner für macOS und Linux. Aktuell führt er einen parallelen Ping-Sweep aus und meldet pro Host: erreichbar (up/down) und Latenz in Millisekunden.
+Ein moderner, stabiler und erweiterbarer Netzwerkscanner für macOS und Linux mit interaktiver Terminal-UI. Führt parallele Ping-Sweeps aus und bietet detaillierte Host-Informationen inklusive Port-Scanning.
 
-Features (Stand jetzt)
-- Parallele Pings mit konfigurierbarer Concurrency
-- Unterstützt CIDR, IP‑Bereiche (z. B. 192.168.1.10-192.168.1.50 oder 192.168.1.10-50) und einzelne IPs
-- Automatische Erkennung des lokalen Netzes (ohne Argumente wird z. B. 192.168.x.x/24 gescannt)
-- Farbige, übersichtliche Tabelle (Status + Latenz) oder JSON-Ausgabe
-- Keine externen Abhängigkeiten (nur Python-Standardbibliothek)
+![Version](https://img.shields.io/badge/version-0.1.1-blue)
+![Python](https://img.shields.io/badge/python-3.9+-green)
+![License](https://img.shields.io/badge/license-MIT-orange)
 
-Voraussetzungen
+## Features
+
+### Kern-Funktionen
+- **Parallele Netzwerk-Scans** mit konfigurierbarer Concurrency
+- **Flexible Zielangabe**: CIDR, IP-Bereiche (z.B. `192.168.1.10-50`) und einzelne IPs
+- **Automatische Netz-Erkennung** (ohne Argumente wird das lokale Netz gescannt)
+- **Comprehensive Port-Scanning**: Top 10.000 Ports mit Service-Erkennung
+- Hostname- und MAC-Auflösung via Reverse DNS, mDNS und ARP
+- **Keine externen Abhängigkeiten** (nur Python-Standardbibliothek)
+
+### Interaktive TUI (Terminal User Interface)
+- **Modernes Split-Panel Layout**:
+  - **Linkes Panel**: Detaillierte Host-Informationen
+    - IP-Adresse, Hostname, MAC-Adresse
+    - Status (UP/DOWN) mit farbiger Kennzeichnung
+    - Latenz-Messung
+    - Liste aller offenen Ports mit Service-Namen
+  - **Rechtes Panel**: Scrollbare Host-Liste (bis zu 254 Hosts)
+- **Live-Netzwerk-Traffic** mit geglätteten Sparkline-Graphen (RX/TX)
+- **Echtzeit-Updates** während des Scannens
+- **Intelligente Port-Scanning**: Automatischer Port-Scan beim Navigieren zwischen Hosts
+- **Flexible Sortierung** nach IP, Status, Latenz, Hostname oder MAC
+- **Filter-Optionen**: Alle Hosts oder nur aktive (UP) Hosts anzeigen
+
+### Ausgabe-Optionen
+- Farbige, übersichtliche Tabelle (CLI)
+- JSON-Ausgabe für Automatisierung
+- Debug-Modus mit detaillierten Informationen
+
+## Voraussetzungen
 - Python 3.9 oder neuer
-- System-Ping vorhanden (macOS: /sbin/ping, Linux: /bin/ping oder ping im PATH)
+- System-Ping vorhanden (macOS: `/sbin/ping`, Linux: `/bin/ping`)
+- Optional (für bessere Hostnamen auf Linux): `avahi-utils` (`avahi-resolve-address`)
 
-Installation (lokal)
-Option A: Direkt als Skript nutzen
+## Installation
+
+### Option A: Direkt als Skript nutzen
 ```bash
 python -m netscan <CIDR|Range|IP>
 # ohne Argumente: lokales Netz automatisch scannen
 python -m netscan
 ```
 
-Option B: Installieren und als CLI nutzen
+### Option B: Installieren und als CLI nutzen
 ```bash
 pip install -e .
 netscan 192.168.1.0/24
+netscan-tui   # interaktive Terminal starten
 ```
 
-Beispiele
+## Verwendung
+
+### CLI-Modus (Schnell-Scan)
 ```bash
-# gesamtes /24-Netz scannen
+# Gesamtes /24-Netz scannen
 netscan 192.168.1.0/24
 
 # Bereichs-Scan
@@ -45,29 +75,111 @@ netscan 10.0.0.0/24 -c 200 -t 1.5 --json
 
 # Farbausgabe deaktivieren
 netscan 192.168.1.0/24 --no-color
+
+# Debug-Modus
+netscan --debug
 ```
 
-CLI-Optionen
-- cidr: Ziel(e) als CIDR/Range/IP
-- -c/--concurrency: Anzahl gleichzeitiger Pings (default 128)
-- -t/--timeout: Timeout pro Paket in Sekunden (default 1.0)
-- --count: ICMP Echo Requests pro Host (default 1)
-- --json: JSON-Ausgabe
-- --no-color: Farbige Ausgabe deaktivieren
+### TUI-Modus (Interaktiv)
+```bash
+netscan-tui
+```
 
-Architektur und Erweiterbarkeit
-- Modul `netscan.scanner` kapselt Ping-Logik und Ziel-Parsing
-- Modul `netscan.cli` stellt die Kommandozeilenoberfläche bereit
-- Ergebnisobjekt enthält ip, up, latency_ms
+#### TUI-Tastenkombinationen
+| Taste | Funktion |
+|-------|----------|
+| `s` | Netzwerk-Scan starten |
+| `r` | Interface/Netz neu erkennen |
+| `a` | Filter umschalten (ALL ↔ UP) |
+| `↑`/`↓` oder `j`/`k` | Host auswählen |
+| `Enter` | Ports des ausgewählten Hosts neu scannen |
+| `1`-`5` | Sortierspalte wählen (1=IP, 2=Status, 3=Latenz, 4=Hostname, 5=MAC) |
+| `o` | Sortierspalte zyklisch wechseln |
+| `O` | Sortierreihenfolge umkehren (↑ ↔ ↓) |
+| `q` | Beenden |
 
-Nächste Schritte (Ideen)
-- ARP/NDP-Discovery für lokale Netze (MAC, Hersteller)
-- TCP-Portscan (syn/conn) optional
-- Service-Erkennung (Banner Grab)
-- IPv6-Unterstützung und parallele Scans gemischt
-- Ausgabeformate: CSV, Markdown, HTML
-- Konfigurierbare Rate Limits und Wiederholungen
+#### TUI-Features im Detail
+- **Live-Traffic-Graphen**: Geglättete Sparklines für RX (magenta) und TX (blau) mit aktuellem Wert und dynamischem Maximum
+- **Auto-Port-Scan**: Beim Navigieren zwischen Hosts werden automatisch die Ports gescannt
+- **Detailliertes Host-Panel**: Zeigt alle relevanten Informationen zum ausgewählten Host
+- **Service-Erkennung**: Bekannte Services werden automatisch erkannt (SSH, HTTP, HTTPS, MySQL, PostgreSQL, RDP, etc.)
+- **Responsive Layout**: Passt sich automatisch an die Terminal-Größe an
 
-Lizenz
+## CLI-Optionen
+- `cidr`: Ziel(e) als CIDR/Range/IP
+- `-c`/`--concurrency`: Anzahl gleichzeitiger Pings (Standard: 128)
+- `-t`/`--timeout`: Timeout pro Paket in Sekunden (Standard: 1.0)
+- `--count`: ICMP Echo Requests pro Host (Standard: 1)
+- `--json`: JSON-Ausgabe
+- `--no-color`: Farbige Ausgabe deaktivieren
+- `--debug`: Detaillierte Debug-Informationen ausgeben
+
+## Port-Scanning
+- **Scan-Bereich**: Top 10.000 Ports (1-10000)
+- **Methode**: TCP-Connect (kein Root erforderlich)
+- **Concurrency**: 256 parallele Verbindungen
+- **Timeout**: 0.5 Sekunden pro Port
+- **Service-Erkennung**: Automatische Zuordnung von Port-Nummern zu Service-Namen
+
+## Architektur
+
+### Module
+- **`netscan.scanner`**: Ping-Logik, Ziel-Parsing, Port-Scanning
+- **`netscan.cli`**: Kommandozeilen-Interface, farbige Tabelle, JSON-Ausgabe
+- **`netscan.tui`**: Interaktive Terminal-UI mit Split-Panel-Layout
+- **`netscan.netinfo`**: Lokales Netzwerk/IP-Ermittlung
+- **`netscan.resolve`**: Hostname-Resolution (PTR + mDNS)
+- **`netscan.arp`**: ARP/Nachbartabelle für MAC-Adressen
+- **`netscan.vendor`**: OUI→Vendor-Zuordnung
+- **`netscan.traffic`**: Netzwerk-Traffic-Monitoring
+
+### Erweiterbarkeit
+- Modularer Aufbau ermöglicht einfache Erweiterungen
+- Ergebnisobjekte enthalten strukturierte Daten (IP, Status, Latenz, Hostname, MAC)
+- Plugin-ready für zusätzliche Scanner-Funktionen
+
+## Zukünftige Features (Roadmap)
+- [ ] Erweiterte OUI-Datenbank für bessere Vendor-Erkennung
+- [ ] Aktives mDNS-Browsing (dns-sd/avahi-browse)
+- [ ] ARP/NDP-Discovery für lokale Netze
+- [ ] Service-Banner-Grabbing
+- [ ] IPv6-Unterstützung
+- [ ] Zusätzliche Ausgabeformate (CSV, Markdown, HTML)
+- [ ] Konfigurierbare Rate-Limits
+- [ ] Scan-Profile (Quick, Normal, Thorough)
+- [ ] Export-Funktion in TUI
+- [ ] Historische Daten und Änderungsverfolgung
+
+## Lizenz
 MIT
 
+## Hinweise
+
+### Vendor-Erkennung
+- Basiert auf OUI-Datenbanken von Wireshark (manuf) oder Nmap (nmap-mac-prefixes)
+- Bevorzugt längste passende Präfixlänge (36 Bit vor 24 Bit)
+- Fallback auf interne Mini-Datenbank
+- Randomisierte MACs werden als "Locally administered (randomized)" erkannt
+
+### Performance-Tipps
+- Für große Netze: Concurrency erhöhen (`-c 256`)
+- Für langsame Netze: Timeout erhöhen (`-t 2.0`)
+- TUI: Auto-Port-Scan kann bei vielen Hosts CPU-intensiv sein
+
+### Bekannte Einschränkungen
+- Port-Scanning nutzt TCP-Connect (langsamer als SYN-Scan, aber kein Root erforderlich)
+- MAC-Adressen nur im lokalen Subnetz verfügbar
+- mDNS-Resolution abhängig vom System-Setup
+
+## Credits
+Entwickelt von Linus Malbertz  
+Inspiriert von nmap, angry IP scanner und btop
+
+---
+
+**Version**: 0.1.1  
+**Letztes Update**: Oktober 2025
+
+## Siehe auch
+- [Release Notes](RELEASE_NOTES.md) - Detaillierte Änderungen und neue Features
+- [LICENSE](LICENSE) - MIT License

--- a/netscan/arp.py
+++ b/netscan/arp.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import platform
+import re
+import subprocess
+from typing import Dict, Optional
+
+
+def _run(cmd: list[str]) -> str:
+    try:
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
+        return p.stdout or ""
+    except Exception:
+        return ""
+
+
+def get_arp_table() -> Dict[str, str]:
+    """Return a best-effort IP->MAC mapping for the local network.
+
+    Works on macOS (arp -an) and Linux (ip neigh / arp -an).
+    """
+    system = platform.system().lower()
+    out = ""
+    if system == "darwin":
+        out = _run(["arp", "-an"])  # (ip) at (mac) on ifscope
+        # Example: ? (192.168.1.1) at a4:xx:xx:xx:xx:xx on en0 ifscope [ethernet]
+        pattern = re.compile(r"\((\d+\.\d+\.\d+\.\d+)\)\s+at\s+([0-9a-f:]{11,})", re.IGNORECASE)
+    else:
+        out = _run(["ip", "neigh"]) or _run(["arp", "-an"])  # fallback
+        # ip neigh: 192.168.1.1 dev wlan0 lladdr a4:xx:xx:xx:xx:xx REACHABLE
+        pattern = re.compile(r"(\d+\.\d+\.\d+\.\d+)\s+.*?lladdr\s+([0-9a-f:]{11,})", re.IGNORECASE)
+        if not pattern.search(out):
+            # fallback parse for arp -an
+            pattern = re.compile(r"\((\d+\.\d+\.\d+\.\d+)\)\s+at\s+([0-9a-f:]{11,})", re.IGNORECASE)
+
+    mapping: Dict[str, str] = {}
+    for ip, mac in pattern.findall(out):
+        mac = mac.lower()
+        mapping[ip] = mac
+    return mapping

--- a/netscan/netinfo.py
+++ b/netscan/netinfo.py
@@ -120,3 +120,13 @@ def get_primary_ipv4() -> Optional[str]:
             return src
     # Fallback via UDP trick
     return _primary_ipv4_via_udp()
+
+
+def get_default_interface() -> Optional[str]:
+    """Return the primary network interface used for default route, if detectable."""
+    system = platform.system().lower()
+    if system == "darwin":
+        return _macos_default_iface()
+    else:
+        iface, _ = _linux_iface_from_route()
+        return iface

--- a/netscan/resolve.py
+++ b/netscan/resolve.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import platform
+import socket
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, Iterable, Optional, List
+import subprocess
+import re
+
+
+def _ptr(ip: str) -> Optional[str]:
+    try:
+        name, _, _ = socket.gethostbyaddr(ip)
+        return name
+    except Exception:
+        return None
+
+
+def resolve_ptrs(ips: Iterable[str], concurrency: int = 32, timeout_per_lookup: float = 0.5) -> Dict[str, Optional[str]]:
+    ips = list(dict.fromkeys(ips))  # de-dup preserve order
+    res: Dict[str, Optional[str]] = {ip: None for ip in ips}
+    if not ips:
+        return res
+    workers = max(1, min(concurrency, len(ips), 128))
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="netscan-dns") as ex:
+        futures = {ex.submit(_ptr, ip): ip for ip in ips}
+        for fut in as_completed(futures, timeout=None):
+            ip = futures[fut]
+            try:
+                res[ip] = fut.result(timeout=timeout_per_lookup)
+            except Exception:
+                res[ip] = None
+
+    # Best-effort fallbacks for unresolved IPs
+    unresolved = [ip for ip, name in res.items() if name is None]
+    if unresolved:
+        # 1) Linux: avahi-resolve-address (mDNS)
+        try:
+            p = subprocess.run(["avahi-resolve-address"] + unresolved, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False, timeout=1.5)
+            out = p.stdout or ""
+            for line in out.splitlines():
+                parts = re.split(r"\s+", line.strip())
+                if len(parts) >= 2:
+                    ip, host = parts[0], parts[1]
+                    if ip in res and res[ip] is None:
+                        res[ip] = host
+        except Exception:
+            pass
+
+        # 2) macOS: dns-sd reverse PTR query per IP
+        if platform.system().lower() == "darwin":
+            def _rev_arpa(ip: str) -> str:
+                parts = ip.split(".")
+                if len(parts) == 4:
+                    return f"{parts[3]}.{parts[2]}.{parts[1]}.{parts[0]}.in-addr.arpa"
+                return ip
+            for ip in list(unresolved):
+                if res.get(ip):
+                    continue
+                try:
+                    qname = _rev_arpa(ip)
+                    p = subprocess.run(["dns-sd", "-Q", qname, "PTR"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False, timeout=1.5)
+                    out = p.stdout or ""
+                    # Look for lines that contain the queried name and a hostname ending with a dot
+                    # Example snippet often includes: "Add     2   4   <qname>.   PTR   <hostname>."
+                    m = re.search(r"PTR\s+([A-Za-z0-9_.-]+)\.?\s*$", out, re.MULTILINE)
+                    if m:
+                        host = m.group(1).rstrip('.')
+                        if host and res.get(ip) is None:
+                            res[ip] = host
+                except Exception:
+                    pass
+
+        # 3) Generic: host or dig reverse lookup
+        still = [ip for ip in unresolved if res.get(ip) is None]
+        if still:
+            # Try `host -W 1 <ip>` (if available)
+            for ip in list(still):
+                try:
+                    p = subprocess.run(["host", "-W", "1", ip], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False, timeout=1.5)
+                    out = (p.stdout or "").strip()
+                    m = re.search(r"pointer\s+([^\s]+)\.?$", out, re.IGNORECASE)
+                    if m:
+                        name = m.group(1).rstrip('.')
+                        if name:
+                            res[ip] = name
+                            continue
+                except Exception:
+                    pass
+            # Try `dig -x <ip> +short +time=1`
+            still2 = [ip for ip in still if res.get(ip) is None]
+            for ip in list(still2):
+                try:
+                    p = subprocess.run(["dig", "-x", ip, "+short", "+time=1"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False, timeout=1.5)
+                    out = (p.stdout or "").strip()
+                    cand = next((ln.strip().rstrip('.') for ln in out.splitlines() if ln.strip()), None)
+                    if cand:
+                        res[ip] = cand
+                except Exception:
+                    pass
+    return res

--- a/netscan/traffic.py
+++ b/netscan/traffic.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import platform
+import re
+import subprocess
+from typing import Optional, Tuple
+
+
+def _run(cmd: list[str]) -> str:
+    try:
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
+        return p.stdout or ""
+    except Exception:
+        return ""
+
+
+def get_bytes_counters(interface: str) -> Optional[Tuple[int, int]]:
+    """Return (rx_bytes, tx_bytes) for the given interface, or None if not found."""
+    system = platform.system().lower()
+    if system == "darwin":
+        out = _run(["netstat", "-ibn"])  # columns include Ibytes Obytes
+        # Name  Mtu   Network     Address            Ibytes     Obytes ...
+        rx = tx = None
+        for line in out.splitlines():
+            parts = line.split()
+            if not parts or parts[0] != interface:
+                continue
+            # Try to locate Ibytes/OBytes assuming typical column order
+            # Some versions have: Name Mtu Net ... Ipkts Ierrs Opkts Oerrs Coll Ibytes Obytes ...
+            m = re.findall(r"\s(\d+)\s(\d+)\s*$", line)
+            # Fallback: parse by column headers position
+            if "Ibytes" in out and "Obytes" in out:
+                # attempt header index mapping
+                header = None
+                for hl in out.splitlines():
+                    if hl.strip().startswith("Name") and "Ibytes" in hl and "Obytes" in hl:
+                        header = hl
+                        break
+                if header:
+                    hcols = header.split()
+                    cols = line.split()
+                    try:
+                        i_idx = hcols.index("Ibytes")
+                        o_idx = hcols.index("Obytes")
+                        rx = int(cols[i_idx])
+                        tx = int(cols[o_idx])
+                        return rx, tx
+                    except Exception:
+                        pass
+            # Very rough fallback: not reliable
+        return None
+    else:
+        # Linux: /proc/net/dev
+        try:
+            with open("/proc/net/dev", "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or ":" not in line:
+                        continue
+                    if_name, rest = [s.strip() for s in line.split(":", 1)]
+                    if if_name != interface:
+                        continue
+                    fields = rest.split()
+                    # fields: recv: bytes packets errs drop fifo frame compressed multicast
+                    #          trans: bytes packets errs drop fifo colls carrier compressed
+                    if len(fields) >= 16:
+                        rx = int(fields[0])
+                        tx = int(fields[8])
+                        return rx, tx
+        except Exception:
+            return None
+        return None

--- a/netscan/tui.py
+++ b/netscan/tui.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+
+import curses
+import time
+import threading
+import textwrap
+import socket
+from typing import List, Optional
+
+from .netinfo import get_default_interface, get_local_network_cidr
+from .traffic import get_bytes_counters
+from .scanner import scan_cidr, port_scan, expand_targets
+from .resolve import resolve_ptrs
+from .arp import get_arp_table
+
+
+class TuiApp:
+    def __init__(self) -> None:
+        self.iface = get_default_interface() or "en0"
+        self.cidr = get_local_network_cidr() or "192.168.1.0/24"
+        self.stop = False
+        self.rx_prev = None
+        self.tx_prev = None
+        self.rx_rate = 0.0
+        self.tx_rate = 0.0
+        self.rate_lock = threading.Lock()
+        self.scan_results: List[dict] = []
+        self.scan_lock = threading.Lock()
+        self.scanning = False
+        self.last_scan_ts: Optional[float] = None
+        # UI state
+        self.only_up = False  # Changed to False to show all hosts by default
+        self.sel = 0
+        self.rx_hist: List[float] = []
+        self.tx_hist: List[float] = []
+        # sorting state
+        self.sort_by = "ip"  # one of: ip, status, latency, hostname, mac
+        self.sort_desc = False
+        # port scan panel
+        self.portscan_target: Optional[str] = None
+        self.portscan_open: List[int] = []
+        self.portscan_running = False
+        # details overlay
+        self.detail_active = False
+        self.detail_ip: Optional[str] = None
+        # auto scan on first launch
+        self.auto_scan_started = False
+        # map ip -> index in scan_results for fast merge
+        self._ip_index: dict[str, int] = {}
+
+    def _update_rates(self) -> None:
+        while not self.stop:
+            counters = get_bytes_counters(self.iface)
+            if counters is not None:
+                rx, tx = counters
+                if self.rx_prev is not None and self.tx_prev is not None:
+                    dt = max(0.001, 1.0)
+                    with self.rate_lock:
+                        self.rx_rate = max(0.0, (rx - self.rx_prev) / dt)
+                        self.tx_rate = max(0.0, (tx - self.tx_prev) / dt)
+                        # history
+                        self.rx_hist.append(self.rx_rate)
+                        self.tx_hist.append(self.tx_rate)
+                        # cap history
+                        max_len = 600
+                        if len(self.rx_hist) > max_len:
+                            self.rx_hist = self.rx_hist[-max_len:]
+                        if len(self.tx_hist) > max_len:
+                            self.tx_hist = self.tx_hist[-max_len:]
+                self.rx_prev, self.tx_prev = rx, tx
+            time.sleep(1.0)
+
+    def _scan(self) -> None:
+        # Start a scan and enrich results incrementally
+        self.scanning = True
+        with self.scan_lock:
+            # Pre-fill all hosts in the CIDR so every IP is visible immediately
+            ips_all = expand_targets(self.cidr)
+            self.scan_results = [
+                {"ip": ip, "up": False, "latency_ms": None, "hostname": None, "mac": None}
+                for ip in ips_all
+            ]
+            self._ip_index = {ip: i for i, ip in enumerate(ips_all)}
+        
+        # Single scan pass with batched enrichment
+        batch: List[dict] = []
+        for r in scan_cidr(self.cidr, concurrency=128, timeout=1.0, count=1, tcp_fallback=True):
+            batch.append(r)
+            if len(batch) >= 32:
+                self._enrich_and_store(batch)
+                batch = []
+        if batch:
+            self._enrich_and_store(batch)
+        self.last_scan_ts = time.time()
+        self.scanning = False
+
+    def _portscan_worker(self, ip: str) -> None:
+        # top 1000 ports: here we use 1-1000 for simplicity. Can be replaced by nmap's top ports list.
+        ports = list(range(1, 10001))
+        try:
+            openp = port_scan(ip, ports, concurrency=256, timeout=0.5)
+        except Exception:
+            openp = []
+        self.portscan_open = openp
+        self.portscan_running = False
+
+    def _open_detail_for_selected(self) -> None:
+        with self.scan_lock:
+            rows = self.scan_results[:]
+        if self.only_up:
+            rows = [r for r in rows if r.get('up')]
+        if not rows:
+            return
+        idx = max(0, min(self.sel, len(rows) - 1))
+        target_ip = rows[idx]['ip']
+        self.detail_active = True
+        self.detail_ip = target_ip
+        # kick off a port scan automatically
+        self.portscan_target = target_ip
+        self.portscan_open = []
+        self.portscan_running = True
+        threading.Thread(target=self._portscan_worker, args=(target_ip,), daemon=True).start()
+
+    def _enrich_and_store(self, batch: List[dict]) -> None:
+        ips = [r["ip"] for r in batch]
+        ptr = resolve_ptrs(ips)
+        arp_map = get_arp_table()
+        for r in batch:
+            r["hostname"] = ptr.get(r["ip"]) or None
+            r["mac"] = arp_map.get(r["ip"]) or None
+        # Merge into pre-filled list by IP
+        with self.scan_lock:
+            for r in batch:
+                ip = r["ip"]
+                idx = self._ip_index.get(ip)
+                if idx is not None and 0 <= idx < len(self.scan_results):
+                    # update fields
+                    self.scan_results[idx].update(r)
+                else:
+                    # if not pre-filled (range change), append
+                    self._ip_index[ip] = len(self.scan_results)
+                    self.scan_results.append(r)
+
+    def draw(self, stdscr) -> None:
+        curses.curs_set(0)
+        stdscr.nodelay(True)
+        stdscr.timeout(250)
+
+        # Launch background rate updater
+        t = threading.Thread(target=self._update_rates, daemon=True)
+        t.start()
+
+        # Colors
+        use_colors = False
+        if curses.has_colors():
+            curses.start_color()
+            curses.use_default_colors()
+            # Pair indices
+            curses.init_pair(1, curses.COLOR_GREEN, -1)  # up
+            curses.init_pair(2, curses.COLOR_RED, -1)    # down
+            curses.init_pair(3, curses.COLOR_CYAN, -1)   # ip
+            curses.init_pair(4, curses.COLOR_YELLOW, -1) # header/help
+            curses.init_pair(5, curses.COLOR_MAGENTA, -1)# graph RX
+            curses.init_pair(7, curses.COLOR_BLUE, -1)   # graph TX
+            curses.init_pair(6, curses.COLOR_BLACK, curses.COLOR_YELLOW)  # selection highlight
+            use_colors = True
+
+        def cpair(n):
+            return curses.color_pair(n) if use_colors else 0
+
+        def smooth(series: List[float], window: int = 4) -> List[float]:
+            if window <= 1 or len(series) <= 2:
+                return series[-width:] if 'width' in locals() else series
+            # simple moving average
+            w = min(window, len(series))
+            out: List[float] = []
+            acc = 0.0
+            q: List[float] = []
+            for v in series:
+                q.append(v)
+                acc += v
+                if len(q) > w:
+                    acc -= q.pop(0)
+                out.append(acc / len(q))
+            return out
+
+        def sparkline(series: List[float], width: int, smooth_window: int = 4) -> str:
+            # Simple 8-level sparkline using unicode blocks
+            if width <= 0:
+                return ""
+            if not series:
+                return " " * width
+            # Take last 'width' samples and normalize
+            data_src = series[-max(width, 20):]  # take a bit more for smoothing
+            data = smooth(data_src, smooth_window)[-width:]
+            maxv = max(data) or 1.0
+            blocks = "▁▂▃▄▅▆▇█"
+            out = []
+            for v in data[-width:]:
+                lvl = int(round((len(blocks) - 1) * (v / maxv)))
+                out.append(blocks[min(len(blocks) - 1, max(0, lvl))])
+            return "".join(out).ljust(width)
+
+        while not self.stop:
+            h, w = stdscr.getmaxyx()
+            stdscr.erase()
+
+            # Auto-start a scan once on first launch
+            if not self.scanning and not self.auto_scan_started:
+                self.auto_scan_started = True
+                threading.Thread(target=self._scan, daemon=True).start()
+
+            # Top: Traffic
+            with self.rate_lock:
+                rx = self.rx_rate
+                tx = self.tx_rate
+            def fmt(bps: float) -> str:
+                units = ["B/s", "KB/s", "MB/s", "GB/s"]
+                i = 0
+                while bps >= 1024 and i < len(units)-1:
+                    bps /= 1024.0
+                    i += 1
+                return f"{bps:6.1f} {units[i]}"
+
+            title = f"netscan-tui  iface={self.iface}  net={self.cidr}  rx={fmt(rx)}  tx={fmt(tx)}  filter={'UP' if self.only_up else 'ALL'}  sort={self.sort_by}{'↓' if self.sort_desc else '↑'}"
+            stdscr.addstr(0, 0, title[: max(0, w - 1)], curses.A_BOLD | cpair(4))
+
+            # Help line
+            help_line = "[s]can  [r]efresh  [a]ctive-only  [1-5] sort col  [o]cycle  [O]asc/desc  [Enter] re-scan ports  ↑/↓ select  [q]uit"
+            stdscr.addstr(1, 0, help_line[: max(0, w - 1)], curses.A_DIM | cpair(4))
+
+            # Graph lines: RX and TX sparklines
+            # Build prettier graphs: labels + current + spark + max scale
+            # determine dynamic widths based on window
+            rx_label = f"RX {fmt(rx)}  "
+            tx_label = f"TX {fmt(tx)}  "
+            with self.rate_lock:
+                rx_max = max(self.rx_hist[-300:] or [0.0])
+                tx_max = max(self.tx_hist[-300:] or [0.0])
+            rx_right = f"  max {fmt(rx_max)}"
+            tx_right = f"  max {fmt(tx_max)}"
+            # compute spark width
+            rx_prefix_len = len(rx_label)
+            tx_prefix_len = len(tx_label)
+            rx_suffix_len = len(rx_right)
+            tx_suffix_len = len(tx_right)
+            rx_w = max(10, w - rx_prefix_len - rx_suffix_len - 1)
+            tx_w = max(10, w - tx_prefix_len - tx_suffix_len - 1)
+            with self.rate_lock:
+                rx_line = sparkline(self.rx_hist, rx_w)
+                tx_line = sparkline(self.tx_hist, tx_w)
+            # RX line in magenta, TX in blue
+            stdscr.addstr(2, 0, (rx_label + rx_line + rx_right)[: max(0, w - 1)], cpair(5))
+            stdscr.addstr(3, 0, (tx_label + tx_line + tx_right)[: max(0, w - 1)], cpair(7))
+
+            # Determine LEFT-side details panel geometry (always visible)
+            panel_active = True
+            # Calculate panel width: minimum 45, maximum 70, about 1/3 of screen
+            panel_w = max(45, min(70, w // 3))
+            # Ensure enough space for the table (minimum 50 columns)
+            if w - panel_w - 2 < 50:
+                panel_w = max(40, w - 52)
+            # Never make it negative or too small
+            if panel_w < 40:
+                panel_w = 40
+            # If screen is too narrow, use half
+            if w < 100:
+                panel_w = max(35, w // 2)
+
+            # Scan area header (for right side)
+            header_y = 5
+            table_x = panel_w + 1  # Start table after panel
+            with self.scan_lock:
+                progress = len(self.scan_results)
+                up_count = sum(1 for r in self.scan_results if r.get('up'))
+            state = 'running' if self.scanning else 'idle'
+            stdscr.addstr(header_y, table_x, f"Scan results ({state})  hosts={progress}", curses.A_BOLD)
+            # Header with sort indicators at fixed columns (relative to table_x)
+            col_ip = table_x
+            col_status = table_x + 17
+            col_latency = table_x + 26
+            col_host = table_x + 37
+            def col_title(name: str, key: str) -> str:
+                if self.sort_by == key:
+                    return f"{name} {'↓' if self.sort_desc else '↑'}"
+                return name
+            header_line = (
+                f"{col_title('IP', 'ip'):<15}  "
+                f"{col_title('Status', 'status'):<6}  "
+                f"{col_title('Latency', 'latency'):<8}  "
+                f"{col_title('Hostname', 'hostname'):<20}  "
+            )
+            stdscr.addstr(header_y + 1, table_x, header_line[: max(0, w - table_x - 1)], curses.A_UNDERLINE)
+
+            # Print results
+            with self.scan_lock:
+                rows = self.scan_results[:]
+            # filter
+            if self.only_up:
+                rows = [r for r in rows if r.get("up")]
+            # sorting
+            def ip_key(ip: str) -> tuple:
+                try:
+                    return tuple(int(p) for p in ip.split("."))
+                except Exception:
+                    return (999, 999, 999, 999)
+            def sort_key(r: dict):
+                k = self.sort_by
+                if k == "ip":
+                    return ip_key(r.get("ip", "255.255.255.255"))
+                if k == "status":
+                    # up first when descending=False => invert bool accordingly
+                    return (0 if r.get("up") else 1)
+                if k == "latency":
+                    lat = r.get("latency_ms")
+                    return (float("inf") if lat is None else lat)
+                if k == "hostname":
+                    return (r.get("hostname") or "").lower()
+                if k == "mac":
+                    return (r.get("mac") or "zz:zz:zz:zz:zz:zz").lower()
+                return ip_key(r.get("ip", "255.255.255.255"))
+            rows.sort(key=sort_key, reverse=self.sort_desc)
+            # ensure selection bounds
+            if rows:
+                self.sel = max(0, min(self.sel, len(rows) - 1))
+            else:
+                self.sel = 0
+
+            # Selected IP for right panel and auto-follow port scan when idle
+            selected_ip: Optional[str] = rows[self.sel]['ip'] if rows else None
+            if selected_ip and selected_ip != self.portscan_target and not self.portscan_running:
+                self.portscan_target = selected_ip
+                self.portscan_open = []
+                self.portscan_running = True
+                threading.Thread(target=self._portscan_worker, args=(selected_ip,), daemon=True).start()
+
+            start_y = header_y + 2
+            max_rows = max(0, h - start_y - 2)
+            # basic scrolling when selection moves beyond viewport
+            top_index = 0
+            if self.sel >= max_rows:
+                top_index = self.sel - max_rows + 1
+
+            for i, r in enumerate(rows[top_index : top_index + max_rows]):
+                y = start_y + i
+                status_up = bool(r.get("up"))
+                status = "UP" if status_up else "DOWN"
+                lat = r.get("latency_ms")
+                lat_s = f"{lat:.2f} ms" if lat is not None else "-"
+                host = (r.get("hostname") or "-")[:20]
+                line = f"{r['ip']:<15}  {status:<6}  {lat_s:<8}  {host:<20}"
+                attrs = 0
+                # colorize ip/status
+                ip_col = cpair(3)
+                st_col = cpair(1) if status_up else cpair(2)
+                # selection highlight
+                if top_index + i == self.sel:
+                    attrs |= curses.A_REVERSE | cpair(6)
+                # print with simple segmentation to colorize parts
+                try:
+                    stdscr.addstr(y, table_x, f"{r['ip']:<15}", ip_col | attrs)
+                    stdscr.addstr(y, table_x + 17, f"{status:<6}", st_col | attrs)
+                    stdscr.addstr(y, table_x + 26, f"{lat_s:<8}", attrs)
+                    stdscr.addstr(y, table_x + 37, f"{host:<20}", attrs)
+                except curses.error:
+                    # If window too small, fallback to single write
+                    content_w = max(0, w - table_x - 1)
+                    stdscr.addstr(y, table_x, line[: content_w], attrs)
+
+            # Portscan status is shown in the left panel; no bottom panel
+
+            # LEFT-side details panel - ALWAYS SHOW IT
+            if panel_active:
+                panel_h = max(10, h - header_y)
+                x0 = 0
+                y0 = header_y
+                # Safety clamp
+                if panel_h > h - y0:
+                    panel_h = h - y0
+                if panel_h < 5:
+                    panel_h = 5
+                
+                # Draw vertical separator
+                try:
+                    vch = getattr(curses, 'ACS_VLINE', ord('|'))
+                    stdscr.vline(y0, panel_w, vch, min(panel_h, h - y0))
+                except curses.error:
+                    pass
+                
+                # Create and draw the panel window
+                try:
+                    win = curses.newwin(panel_h, panel_w, y0, x0)
+                    win.box()
+                    inner_w = max(10, panel_w - 2)
+                    row = 1
+                    
+                    def put(line: str, attr: int = 0):
+                        nonlocal row
+                        if row >= panel_h - 1:
+                            return
+                        try:
+                            display_line = line[:inner_w] if len(line) > inner_w else line
+                            win.addstr(row, 1, display_line.ljust(inner_w), attr)
+                        except curses.error:
+                            pass
+                        row += 1
+                except Exception as e:
+                    # If panel creation fails, show error on main screen
+                    try:
+                        err_msg = f"Panel ERR: {type(e).__name__} {str(e)[:20]}"
+                        stdscr.addstr(header_y + 1, 0, err_msg, curses.A_DIM)
+                    except:
+                        pass
+                else:
+
+                    # Title
+                    title = " ═══ HOST DETAILS ═══ "
+                    try:
+                        win.addstr(0, max(1, (panel_w - len(title)) // 2), title, curses.A_BOLD | cpair(4))
+                    except curses.error:
+                        pass
+
+                    # Info for selected IP
+                    info = None
+                    target_ip = selected_ip
+                    with self.scan_lock:
+                        for r in self.scan_results:
+                            if r.get('ip') == target_ip:
+                                info = r
+                                break
+                    if info:
+                        status_up = bool(info.get('up'))
+                        status = "UP" if status_up else "DOWN"
+                        status_col = cpair(1) if status_up else cpair(2)
+                        lat = info.get('latency_ms')
+                        lat_s = f"{lat:.2f} ms" if lat is not None else "-"
+                        
+                        # Format like in the screenshot - with nice spacing
+                        put("")
+                        put("┌─ Network Information", curses.A_BOLD | cpair(4))
+                        put("│")
+                        put(f"│ IP Address:", curses.A_BOLD)
+                        put(f"│   {info.get('ip')}", cpair(3) | curses.A_BOLD)
+                        put("│")
+                        put(f"│ Hostname:", curses.A_BOLD)
+                        hostname = info.get('hostname') or 'Not resolved'
+                        put(f"│   {hostname}")
+                        put("│")
+                        put(f"│ MAC Address:", curses.A_BOLD)
+                        mac = info.get('mac') or 'Unknown'
+                        put(f"│   {mac}")
+                        put("│")
+                        put(f"│ Status:", curses.A_BOLD)
+                        put(f"│   {status}", status_col | curses.A_BOLD)
+                        put("│")
+                        put(f"│ Latency:", curses.A_BOLD)
+                        put(f"│   {lat_s}")
+                        put("│")
+                        put("└" + "─" * (inner_w - 1))
+                        put("")
+                        put("┌─ Open TCP Ports", curses.A_BOLD | cpair(4))
+                        put("┌─ Open TCP Ports", curses.A_BOLD | cpair(4))
+                    else:
+                        put("")
+                        put("┌─ Network Information", curses.A_BOLD | cpair(4))
+                        put("│")
+                        put(f"│ IP Address:", curses.A_BOLD)
+                        put(f"│   {target_ip or '-'}", cpair(3))
+                        put("│")
+                        put(f"│ Hostname:", curses.A_BOLD)
+                        put("│   Not scanned")
+                        put("│")
+                        put(f"│ MAC Address:", curses.A_BOLD)
+                        put("│   Unknown")
+                        put("│")
+                        put(f"│ Status:", curses.A_BOLD)
+                        put("│   Unknown", curses.A_DIM)
+                        put("│")
+                        put("└" + "─" * (inner_w - 1))
+                        put("")
+                        put("Press 's' to start network scan", curses.A_DIM)
+                        put("")
+                        put("┌─ Open TCP Ports", curses.A_BOLD | cpair(4))
+
+                    # Show port scan results with service names
+                    put("│")
+                    if self.portscan_running:
+                        put("│ ⟳ Scanning ports...", curses.A_DIM | cpair(4))
+                    else:
+                        def svc(p: int) -> str:
+                            try:
+                                return socket.getservbyport(p, 'tcp')
+                            except Exception:
+                                # common fallbacks
+                                common = {
+                                    21: 'ftp', 22: 'ssh', 23: 'telnet', 25: 'smtp',
+                                    53: 'domain', 80: 'http', 110: 'pop3', 143: 'imap',
+                                    443: 'https', 445: 'smb', 3306: 'mysql', 3389: 'rdp',
+                                    5432: 'postgresql', 5900: 'vnc', 6379: 'redis',
+                                    8080: 'http-proxy', 8443: 'https-alt', 27017: 'mongodb'
+                                }
+                                return common.get(p, 'unknown')
+                        shown = 0
+                        if self.portscan_open:
+                            for p in self.portscan_open:
+                                service = svc(p)
+                                put(f"│ • {p:>5}/tcp  →  {service}", cpair(1))
+                                shown += 1
+                                if row >= panel_h - 3:
+                                    remaining = max(0, len(self.portscan_open) - shown)
+                                    if remaining:
+                                        put(f"│ ... and {remaining} more ports")
+                                    break
+                        else:
+                            put("│ No open ports found", curses.A_DIM)
+                    put("│")
+                    put("└" + "─" * (inner_w - 1))
+                    put("")
+                    put("╔═══ CONTROLS ═══", curses.A_BOLD | cpair(4))
+                    put("║")
+                    put("║ [↑/↓]    Navigate hosts", curses.A_DIM)
+                    put("║ [Enter]  Rescan ports", curses.A_DIM)
+                    put("║ [s]      Scan network", curses.A_DIM)
+                    put("║ [a]      Toggle filter (ALL/UP)", curses.A_DIM)
+                    put("║ [1-5]    Sort by column", curses.A_DIM)
+                    put("║ [o]      Cycle sort", curses.A_DIM)
+                    put("║ [q]      Quit", curses.A_DIM)
+                    put("╚" + "═" * (inner_w - 1))
+                    # Don't refresh panel yet - wait until after stdscr
+
+            # Footer
+            if self.last_scan_ts:
+                stdscr.addstr(h - 1, 0, time.strftime("Last scan: %Y-%m-%d %H:%M:%S", time.localtime(self.last_scan_ts)), curses.A_DIM)
+
+            # Batch refresh: stdscr first, then panel on top
+            stdscr.noutrefresh()
+            if panel_active and 'win' in locals():
+                try:
+                    win.noutrefresh()
+                except:
+                    pass
+            try:
+                curses.doupdate()
+            except Exception:
+                stdscr.refresh()
+
+            # Handle keys
+            try:
+                ch = stdscr.getch()
+            except Exception:
+                ch = -1
+
+            if ch == ord('q'):
+                self.stop = True
+                break
+            elif ch == ord('s') and not self.scanning:
+                threading.Thread(target=self._scan, daemon=True).start()
+            elif ch == ord('r'):
+                # refresh detection
+                self.iface = get_default_interface() or self.iface
+                self.cidr = get_local_network_cidr() or self.cidr
+            elif ch == ord('a'):
+                self.only_up = not self.only_up
+                self.sel = 0
+            elif ch == ord('o'):
+                # cycle sort column
+                order = ["ip", "status", "latency", "hostname", "mac"]
+                try:
+                    idx = (order.index(self.sort_by) + 1) % len(order)
+                except ValueError:
+                    idx = 0
+                self.sort_by = order[idx]
+            elif ch == ord('O'):
+                self.sort_desc = not self.sort_desc
+            elif ch in (ord('1'), ord('2'), ord('3'), ord('4'), ord('5')):
+                mapping = {
+                    ord('1'): "ip",
+                    ord('2'): "status",
+                    ord('3'): "latency",
+                    ord('4'): "hostname",
+                    ord('5'): "mac",
+                }
+                self.sort_by = mapping.get(ch, self.sort_by)
+            elif ch in (10, 13, curses.KEY_ENTER):  # Enter re-scans ports for selected
+                if rows:
+                    target_ip = rows[self.sel]['ip']
+                    if target_ip:
+                        self.portscan_target = target_ip
+                        self.portscan_open = []
+                        self.portscan_running = True
+                        threading.Thread(target=self._portscan_worker, args=(target_ip,), daemon=True).start()
+            elif ch == ord('p'):
+                # scan top 1000 ports for selected host
+                with self.scan_lock:
+                    rows = self.scan_results[:]
+                if self.only_up:
+                    rows = [r for r in rows if r.get('up')]
+                if not rows:
+                    continue
+                idx = max(0, min(self.sel, len(rows) - 1))
+                target_ip = rows[idx]['ip']
+                if target_ip:
+                    self.portscan_target = target_ip
+                    self.portscan_open = []
+                    self.portscan_running = True
+                    threading.Thread(target=self._portscan_worker, args=(target_ip,), daemon=True).start()
+
+            elif ch in (curses.KEY_UP, ord('k')):
+                if self.sel > 0:
+                    self.sel -= 1
+                    # auto-trigger scan for new selection if idle
+                    if not self.portscan_running and rows:
+                        new_ip = rows[self.sel]['ip']
+                        if new_ip and new_ip != self.portscan_target:
+                            self.portscan_target = new_ip
+                            self.portscan_open = []
+                            self.portscan_running = True
+                            threading.Thread(target=self._portscan_worker, args=(new_ip,), daemon=True).start()
+            elif ch in (curses.KEY_DOWN, ord('j')):
+                with self.scan_lock:
+                    n = len([r for r in self.scan_results if (r.get('up') if self.only_up else True)])
+                if self.sel < max(0, n - 1):
+                    self.sel += 1
+                    # auto-trigger scan for new selection if idle
+                    if not self.portscan_running and rows:
+                        new_ip = rows[self.sel]['ip']
+                        if new_ip and new_ip != self.portscan_target:
+                            self.portscan_target = new_ip
+                            self.portscan_open = []
+                            self.portscan_running = True
+                            threading.Thread(target=self._portscan_worker, args=(new_ip,), daemon=True).start()
+
+        # end loop
+
+
+def main() -> int:
+    app = TuiApp()
+    curses.wrapper(app.draw)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/netscan/vendor.py
+++ b/netscan/vendor.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import os
+import re
+from typing import Dict, Optional, Tuple
+
+
+# Built-in tiny fallback to avoid showing nonsense when DB is missing
+_OUI_FALLBACK: Dict[str, str] = {
+    # A few common examples only; real coverage comes from external DBs
+    "A45E60": "Apple, Inc.",
+    "BC2411": "Apple, Inc.",
+    "703EAC": "Apple, Inc.",
+    "001A11": "Cisco Systems",
+    "B827EB": "Raspberry Pi Foundation",
+    "F0B479": "Samsung Electronics",
+}
+
+
+def _find_vendor_files() -> list[str]:
+    # Common install locations for Wireshark and Nmap databases
+    candidates = [
+        # Wireshark manuf
+        "/usr/share/wireshark/manuf",
+        "/usr/local/share/wireshark/manuf",
+        "/opt/homebrew/share/wireshark/manuf",  # macOS (ARM)
+        # Nmap mac prefixes
+        "/usr/share/nmap/nmap-mac-prefixes",
+        "/usr/local/share/nmap/nmap-mac-prefixes",
+        "/opt/homebrew/share/nmap/nmap-mac-prefixes",
+    ]
+    return [p for p in candidates if os.path.exists(p)]
+
+
+def _parse_manuf_line(line: str) -> Optional[Tuple[str, int, str]]:
+    # Wireshark format: "00:00:0C Cisco" or with prefix "AC:DE:48:00:00:00/36 SomeVendor"
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+    parts = re.split(r"\s+", line, maxsplit=2)
+    if not parts:
+        return None
+    key = parts[0]
+    name = parts[1] if len(parts) > 1 else ""
+    if "/" in key:
+        mac_part, plen = key.split("/", 1)
+        try:
+            plen = int(plen)
+        except ValueError:
+            return None
+    else:
+        mac_part, plen = key, 24  # default 24-bit OUI
+    mac_hex = re.sub(r"[^0-9A-Fa-f]", "", mac_part).upper()
+    if not mac_hex:
+        return None
+    # Store as hex string without separators, with prefix length in bits
+    return mac_hex, int(plen), name
+
+
+def _parse_nmap_line(line: str) -> Optional[Tuple[str, int, str]]:
+    # Nmap format: "000000  XEROX CORPORATION"
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+    m = re.match(r"^([0-9A-Fa-f]{6,12})\s+(.+)$", line)
+    if not m:
+        return None
+    hexpart = m.group(1).upper()
+    name = m.group(2).strip()
+    plen = 4 * len(hexpart)  # 24 or 36 typically
+    return hexpart, plen, name
+
+
+def _load_oui_db() -> Dict[Tuple[int, str], str]:
+    """Load OUI DB from Wireshark/Nmap if available.
+
+    Returns a map keyed by (prefix_len_bits, hex_prefix) -> vendor.
+    Longer prefixes should be preferred during lookup.
+    """
+    db: Dict[Tuple[int, str], str] = {}
+    for path in _find_vendor_files():
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    rec = None
+                    if path.endswith("manuf"):
+                        rec = _parse_manuf_line(line)
+                    else:
+                        rec = _parse_nmap_line(line)
+                    if not rec:
+                        continue
+                    hex_prefix, plen, name = rec
+                    # Normalize prefix to exact nibble boundary
+                    nibs = plen // 4
+                    hex_prefix = hex_prefix[:nibs]
+                    if nibs >= 6:  # at least 24-bit OUI
+                        db[(plen, hex_prefix)] = name
+        except Exception:
+            continue
+    # If nothing loaded, seed with fallback as 24-bit (6 hex digits)
+    if not db:
+        for hex6, name in _OUI_FALLBACK.items():
+            db[(24, hex6)] = name
+    return db
+
+
+_DB = _load_oui_db()
+_PREFERRED_PREFIXES = sorted({plen for (plen, _k) in _DB.keys()}, reverse=True)  # e.g., [36, 24]
+
+
+def _is_locally_administered(hex12: str) -> bool:
+    """Detect Locally Administered Address (randomized MAC), based on first octet bit 1."""
+    if len(hex12) < 2:
+        return False
+    try:
+        first_octet = int(hex12[:2], 16)
+    except ValueError:
+        return False
+    return bool(first_octet & 0x02)
+
+
+def vendor_from_mac(mac: str) -> Optional[str]:
+    if not mac:
+        return None
+    hex_only = "".join(c for c in mac if c.isalnum()).upper()
+    if len(hex_only) < 12:
+        # Not a full MAC, try best-effort on available prefix
+        if len(hex_only) >= 6:
+            for plen in _PREFERRED_PREFIXES:
+                nibs = plen // 4
+                if len(hex_only) >= nibs:
+                    name = _DB.get((plen, hex_only[:nibs]))
+                    if name:
+                        return name
+        return None
+
+    # If locally administered (randomized), OUI mapping is meaningless
+    if _is_locally_administered(hex_only):
+        return "Locally administered (randomized)"
+
+    # Longest-prefix match (prefer 36-bit if present, then 24-bit)
+    for plen in _PREFERRED_PREFIXES:
+        nibs = plen // 4
+        if len(hex_only) >= nibs:
+            name = _DB.get((plen, hex_only[:nibs]))
+            if name:
+                return name
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = []
 
 [project.scripts]
 netscan = "netscan.cli:main"
+netscan-tui = "netscan.tui:main"
 
 [tool.setuptools]
 packages = ["netscan"]


### PR DESCRIPTION
# Network Scanner (macOS + Linux)

Ein moderner, stabiler und erweiterbarer Netzwerkscanner für macOS und Linux mit interaktiver Terminal-UI. Führt parallele Ping-Sweeps aus und bietet detaillierte Host-Informationen inklusive Port-Scanning.

![Version](https://img.shields.io/badge/version-0.1.1-blue)
![Python](https://img.shields.io/badge/python-3.9+-green)
![License](https://img.shields.io/badge/license-MIT-orange)

## Features

### Kern-Funktionen
- **Parallele Netzwerk-Scans** mit konfigurierbarer Concurrency
- **Flexible Zielangabe**: CIDR, IP-Bereiche (z.B. `192.168.1.10-50`) und einzelne IPs
- **Automatische Netz-Erkennung** (ohne Argumente wird das lokale Netz gescannt)
- **Comprehensive Port-Scanning**: Top 10.000 Ports mit Service-Erkennung
- Hostname- und MAC-Auflösung via Reverse DNS, mDNS und ARP
- **Keine externen Abhängigkeiten** (nur Python-Standardbibliothek)

### Interaktive TUI (Terminal User Interface)
- **Modernes Split-Panel Layout**:
  - **Linkes Panel**: Detaillierte Host-Informationen
    - IP-Adresse, Hostname, MAC-Adresse
    - Status (UP/DOWN) mit farbiger Kennzeichnung
    - Latenz-Messung
    - Liste aller offenen Ports mit Service-Namen
  - **Rechtes Panel**: Scrollbare Host-Liste (bis zu 254 Hosts)
- **Live-Netzwerk-Traffic** mit geglätteten Sparkline-Graphen (RX/TX)
- **Echtzeit-Updates** während des Scannens
- **Intelligente Port-Scanning**: Automatischer Port-Scan beim Navigieren zwischen Hosts
- **Flexible Sortierung** nach IP, Status, Latenz, Hostname oder MAC
- **Filter-Optionen**: Alle Hosts oder nur aktive (UP) Hosts anzeigen

### Ausgabe-Optionen
- Farbige, übersichtliche Tabelle (CLI)
- JSON-Ausgabe für Automatisierung
- Debug-Modus mit detaillierten Informationen

## Voraussetzungen
- Python 3.9 oder neuer
- System-Ping vorhanden (macOS: `/sbin/ping`, Linux: `/bin/ping`)
- Optional (für bessere Hostnamen auf Linux): `avahi-utils` (`avahi-resolve-address`)

## Installation

### Option A: Direkt als Skript nutzen
```bash
python -m netscan <CIDR|Range|IP>
# ohne Argumente: lokales Netz automatisch scannen
python -m netscan
```

### Option B: Installieren und als CLI nutzen
```bash
pip install -e .
netscan 192.168.1.0/24
netscan-tui   # interaktive Terminal starten
```

## Verwendung

### CLI-Modus (Schnell-Scan)
```bash
# Gesamtes /24-Netz scannen
netscan 192.168.1.0/24

# Bereichs-Scan
netscan 192.168.1.10-192.168.1.50
netscan 192.168.1.10-50

# Einzelne IP
netscan 192.168.1.20

# JSON-Ausgabe mit 200 gleichzeitigen Pings und 1.5s Timeout
netscan 10.0.0.0/24 -c 200 -t 1.5 --json

# Farbausgabe deaktivieren
netscan 192.168.1.0/24 --no-color

# Debug-Modus
netscan --debug
```

### TUI-Modus (Interaktiv)
```bash
netscan-tui
```

#### TUI-Tastenkombinationen
| Taste | Funktion |
|-------|----------|
| `s` | Netzwerk-Scan starten |
| `r` | Interface/Netz neu erkennen |
| `a` | Filter umschalten (ALL ↔ UP) |
| `↑`/`↓` oder `j`/`k` | Host auswählen |
| `Enter` | Ports des ausgewählten Hosts neu scannen |
| `1`-`5` | Sortierspalte wählen (1=IP, 2=Status, 3=Latenz, 4=Hostname, 5=MAC) |
| `o` | Sortierspalte zyklisch wechseln |
| `O` | Sortierreihenfolge umkehren (↑ ↔ ↓) |
| `q` | Beenden |

#### TUI-Features im Detail
- **Live-Traffic-Graphen**: Geglättete Sparklines für RX (magenta) und TX (blau) mit aktuellem Wert und dynamischem Maximum
- **Auto-Port-Scan**: Beim Navigieren zwischen Hosts werden automatisch die Ports gescannt
- **Detailliertes Host-Panel**: Zeigt alle relevanten Informationen zum ausgewählten Host
- **Service-Erkennung**: Bekannte Services werden automatisch erkannt (SSH, HTTP, HTTPS, MySQL, PostgreSQL, RDP, etc.)
- **Responsive Layout**: Passt sich automatisch an die Terminal-Größe an

## CLI-Optionen
- `cidr`: Ziel(e) als CIDR/Range/IP
- `-c`/`--concurrency`: Anzahl gleichzeitiger Pings (Standard: 128)
- `-t`/`--timeout`: Timeout pro Paket in Sekunden (Standard: 1.0)
- `--count`: ICMP Echo Requests pro Host (Standard: 1)
- `--json`: JSON-Ausgabe
- `--no-color`: Farbige Ausgabe deaktivieren
- `--debug`: Detaillierte Debug-Informationen ausgeben

## Port-Scanning
- **Scan-Bereich**: Top 10.000 Ports (1-10000)
- **Methode**: TCP-Connect (kein Root erforderlich)
- **Concurrency**: 256 parallele Verbindungen
- **Timeout**: 0.5 Sekunden pro Port
- **Service-Erkennung**: Automatische Zuordnung von Port-Nummern zu Service-Namen

## Architektur

### Module
- **`netscan.scanner`**: Ping-Logik, Ziel-Parsing, Port-Scanning
- **`netscan.cli`**: Kommandozeilen-Interface, farbige Tabelle, JSON-Ausgabe
- **`netscan.tui`**: Interaktive Terminal-UI mit Split-Panel-Layout
- **`netscan.netinfo`**: Lokales Netzwerk/IP-Ermittlung
- **`netscan.resolve`**: Hostname-Resolution (PTR + mDNS)
- **`netscan.arp`**: ARP/Nachbartabelle für MAC-Adressen
- **`netscan.vendor`**: OUI→Vendor-Zuordnung
- **`netscan.traffic`**: Netzwerk-Traffic-Monitoring

### Erweiterbarkeit
- Modularer Aufbau ermöglicht einfache Erweiterungen
- Ergebnisobjekte enthalten strukturierte Daten (IP, Status, Latenz, Hostname, MAC)
- Plugin-ready für zusätzliche Scanner-Funktionen

## Zukünftige Features (Roadmap)
- [ ] Erweiterte OUI-Datenbank für bessere Vendor-Erkennung
- [ ] Aktives mDNS-Browsing (dns-sd/avahi-browse)
- [ ] ARP/NDP-Discovery für lokale Netze
- [ ] Service-Banner-Grabbing
- [ ] IPv6-Unterstützung
- [ ] Zusätzliche Ausgabeformate (CSV, Markdown, HTML)
- [ ] Konfigurierbare Rate-Limits
- [ ] Scan-Profile (Quick, Normal, Thorough)
- [ ] Export-Funktion in TUI
- [ ] Historische Daten und Änderungsverfolgung

## Lizenz
MIT

## Hinweise

### Vendor-Erkennung
- Basiert auf OUI-Datenbanken von Wireshark (manuf) oder Nmap (nmap-mac-prefixes)
- Bevorzugt längste passende Präfixlänge (36 Bit vor 24 Bit)
- Fallback auf interne Mini-Datenbank
- Randomisierte MACs werden als "Locally administered (randomized)" erkannt

### Performance-Tipps
- Für große Netze: Concurrency erhöhen (`-c 256`)
- Für langsame Netze: Timeout erhöhen (`-t 2.0`)
- TUI: Auto-Port-Scan kann bei vielen Hosts CPU-intensiv sein

### Bekannte Einschränkungen
- Port-Scanning nutzt TCP-Connect (langsamer als SYN-Scan, aber kein Root erforderlich)
- MAC-Adressen nur im lokalen Subnetz verfügbar
- mDNS-Resolution abhängig vom System-Setup

## Credits
Entwickelt von Linus Malbertz  
Inspiriert von nmap, angry IP scanner und btop

---

**Version**: 0.1.1  
**Letztes Update**: Oktober 2025

## Siehe auch
- [Release Notes](RELEASE_NOTES.md) - Detaillierte Änderungen und neue Features
- [LICENSE](LICENSE) - MIT License
